### PR TITLE
Remove 10-ubuntu-core-secure-path

### DIFF
--- a/config/etc/sudoers.d/10-ubuntu-core-secure-path
+++ b/config/etc/sudoers.d/10-ubuntu-core-secure-path
@@ -1,1 +1,0 @@
-Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"


### PR DESCRIPTION
This was merged to the ubuntu sudo package and can be dropped

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>