### PR TITLE
Remove snapd.generate-network-conf.service

### DIFF
--- a/config/lib/systemd/system/snapd.generate-network-conf.service
+++ b/config/lib/systemd/system/snapd.generate-network-conf.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Generate default network config
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=/usr/lib/snapd/generate-network-conf


### PR DESCRIPTION
It predates the current netplan-based solution.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>