### PR TITLE
Update cloud-init configuration

### DIFF
--- a/config/etc/cloud/cloud.cfg.d/10_snappy.cfg
+++ b/config/etc/cloud/cloud.cfg.d/10_snappy.cfg
@@ -10,9 +10,12 @@ growpart:
 resize_rootfs: False
 
 # lock_passwd writes warning due to failure of 'usermod --lock'
+# use netplan for rendering network config
 system_info:
    default_user:
      lock_passwd: True
+   network:
+       renderers: ['netplan']
 
 # disable running 'locale-gen' as it does not run successfully
 locale: False
@@ -23,6 +26,3 @@ grub_dpkg:
 
 # apt_pipelining logs warning on failed write to /etc/apt/apt.conf.d
 apt_pipelining: "none"
-
-# 'apt_configure' module should not run as apt is not used.
-apt_configure_enabled: False

--- a/config/etc/cloud/ds-identify.cfg
+++ b/config/etc/cloud/ds-identify.cfg
@@ -1,0 +1,1 @@
+search,found=first,maybe=all,notfound=disabled

--- a/config/etc/cloud/ds-identify.cfg
+++ b/config/etc/cloud/ds-identify.cfg
@@ -1,1 +1,2 @@
-search,found=first,maybe=all,notfound=disabled
+policy: search,found=first,maybe=all,notfound=disabled
+ci.datasource.ec2.strict_id=true

--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -20,7 +20,6 @@
 /var/lib/bluetooth                      auto                    persistent  none        none
 # cloud-init
 /etc/cloud                              auto                    synced  none        none
-/etc/cloud/cloud.cfg.d                  auto                    synced  none        none
 /var/lib/cloud                          auto                    persistent  none        none
 /var/lib/colord                         auto                    persistent  transition  none
 /var/lib/dbus                           auto                    persistent  none        none

--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -19,7 +19,8 @@
 /var/snap                              auto                    persistent  transition  none
 /var/lib/bluetooth                      auto                    persistent  none        none
 # cloud-init
-/etc/cloud                              auto                    persistent  none        none
+/etc/cloud                              auto                    synced  none        none
+/etc/cloud/cloud.cfg.d                  auto                    synced  none        none
 /var/lib/cloud                          auto                    persistent  none        none
 /var/lib/colord                         auto                    persistent  transition  none
 /var/lib/dbus                           auto                    persistent  none        none


### PR DESCRIPTION
- Add cloud-init datasource identify policy (ds-identify.cfg). The policy
  configured requires cloud-init systemd generator to detect local
  datasource to enable cloud-init, otherwise it will remain disabled.
- Enable cloud-init to use netplan renderer for network configurations
- Update writable-paths to sync /etc/cloud and /etc/cloud.cfg.d which
  enables the default configuration of cloud-init in the core image to be
  merged with configuration files which are added to the writable
  partition.
- Dropped apt_configure configuration, it wasn't correct and cloud-init
  now skips running this module if the system it's running on is
  Ubuntu Core