### PR TITLE
make /etc/environment writable

### DIFF
--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -107,4 +107,6 @@
 /etc/rsyslog.d                          auto                    persistent  transition  none
 /etc/systemd/timesyncd.conf             auto                    persistent  transition  none
 /etc/default/swapfile                   auto                    persistent  transition  none
+# allow system wide proxy setting
+/etc/environment                        auto                    persistent  transition  none
 


### PR DESCRIPTION
Make /etc/environment writable to allow setting a system wide proxy on UbuntuCore images