### PR TITLE
remove cruft from the writable-paths

### DIFF
--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -13,27 +13,18 @@
 /tmp                                    none                    temporary   none        defaults
 /mnt                                    none                    temporary   none        defaults
 /media                                  none                    temporary   none        defaults
-/var/crash                              auto                    persistent  none        none
-/var/lib/AccountsService/users          auto                    persistent  none        none
 # snap data
 /var/snap                              auto                    persistent  transition  none
-/var/lib/bluetooth                      auto                    persistent  none        none
 # cloud-init
 /etc/cloud                              auto                    persistent  none        none
 /var/lib/cloud                          auto                    persistent  none        none
-/var/lib/colord                         auto                    persistent  transition  none
+# dbus machine-id
 /var/lib/dbus                           auto                    persistent  none        none
+# FIXME: do we need this in the world of networkd?
 /var/lib/dhcp                           auto                    persistent  none        none
 /var/lib/logrotate                      auto                    persistent  none        none
 /var/lib/sudo                           auto                    temporary   none        defaults,mode=0700
-/var/lib/system-image                   auto                    persistent  none        none
-/var/lib/upower                         auto                    persistent  none        none
-/var/lib/lightdm                        auto                    persistent  none        none
-/var/lib/lightdm-data                   auto                    persistent  none        none
 /var/log                                auto                    persistent  transition  none
-/var/lib/NetworkManager                 auto                    temporary   none        defaults
-/var/lib/usermetrics                    auto                    persistent  none        none
-/var/lib/ubuntu-location-service        auto                    persistent  none        none
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none
 /etc/default/keyboard                   auto                    persistent  transition  none
@@ -42,35 +33,29 @@
 # needed by apparmor - use transition since some core apps are
 # pre-installed on the image
 /var/cache/apparmor                     auto                    persistent  transition  none
+# FIXME: do we still need this?
 /var/lib/apparmor                       auto                    persistent  transition  none
-/var/lib/whoopsie                       auto                    persistent  transition  none
 # required by update-initramfs
 /var/tmp                                auto                    persistent  transition  none
 # ssh
 /etc/ssh                                auto                    persistent  transition  none
-/etc/init                               auto                    persistent  transition  none
 # used for various writable files (timezone, localtime, ...)
 /etc/writable                           auto                    synced      none        none
-# ureadahead
-/var/lib/ureadahead                     auto                    persistent  transition  none
+# FIXME: why do we need this?
 # required by update-initramfs
 /var/lib/initramfs-tools                auto                    persistent  transition  none
 # systemd
 /etc/systemd/system                     auto                    persistent  transition  none
-# needed for usb tethering
-/var/lib/misc                           auto                    persistent  transition  none
-# walinuxagent
-/var/lib/waagent                        auto                    persistent  transition  none
 # ssh keys
 /root                                   auto                    persistent  transition  none
 # passwordless sudo
 /etc/sudoers.d                          auto                    persistent  transition  none
 /etc/hosts                              auto                    persistent  transition  none
 /var/lib/extrausers                     auto                    persistent  transition  none
+# FIXME: do we still need this?
 /etc/network/interfaces.d               auto                    persistent  transition  none
 # needed to persist ntp enabled/disabled
 /etc/network/if-up.d                    auto                    persistent  transition  none
-/etc/NetworkManager/system-connections  auto                    persistent  none        none
 # snappy security policy, etc
 /var/lib/snapd                         auto                    persistent  transition  none
 # udev
@@ -82,9 +67,8 @@
 # dbus bus policy
 /etc/dbus-1/system.d                    auto                    persistent  transition  none
 /etc/modprobe.d                         auto                    synced      none        none
+# FIXME: do we still need ppp on the image?
 /etc/ppp                                auto                    persistent  transition  none
-/var/lib/tpm                            auto                    persistent  transition  none
-/var/lib/opencryptoki                   auto                    persistent  transition  none
 /etc/modules-load.d                     auto                    persistent  transition  none
 # LP: 1562784
 /etc/systemd/network                    auto                    persistent  transition  none
@@ -94,7 +78,9 @@
 /etc/systemd/system.conf.d              auto                    persistent  transition  none
 /etc/systemd/user.conf.d                auto                    persistent  transition  none
 /etc/systemd/logind.conf.d              auto                    persistent  transition  none
+# FIXME: what is this used for?
 /etc/iproute2                           auto                    persistent  transition  none
+# FIXME: why do we need this in the systemd age?
 /etc/rc0.d                              auto                    persistent  transition  none
 /etc/rc1.d                              auto                    persistent  transition  none
 /etc/rc2.d                              auto                    persistent  transition  none
@@ -104,6 +90,7 @@
 /etc/rc6.d                              auto                    persistent  transition  none
 /etc/rcS.d                              auto                    persistent  transition  none
 /etc/init.d                             auto                    persistent  transition  none
+# syslog
 /etc/rsyslog.d                          auto                    persistent  transition  none
 /etc/systemd/timesyncd.conf             auto                    persistent  transition  none
 /etc/default/swapfile                   auto                    persistent  transition  none


### PR DESCRIPTION
It looks like we accumulated some cruft in our writable-path file. This branch removes the bits that were used to make a ubuntu-personal core snap and adds a bunch of FIXMEs around things where it is not entirely clear why they exist in there.