### PR TITLE
cloud-init: fix strict mode, ensure cloud-init only runs on positive id

### DIFF
--- a/config/etc/cloud/ds-identify.cfg
+++ b/config/etc/cloud/ds-identify.cfg
@@ -1,2 +1,2 @@
-policy: search,found=first,maybe=all,notfound=disabled
+policy: search,found=first,maybe=none,notfound=disabled
 ci.datasource.ec2.strict_id=true


### PR DESCRIPTION
cloud-init still runs when no local datasource is present unless we ignore maybe datasources (ones that may be populated later during boot).  Core uses strict mode which requires positive identification or cloud-init doesn't run.