### PR TITLE
switch /etc/systemd/system to "synced" mode

### DIFF
--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -56,7 +56,7 @@
 # required by update-initramfs
 /var/lib/initramfs-tools                auto                    persistent  transition  none
 # systemd
-/etc/systemd/system                     auto                    persistent  transition  none
+/etc/systemd/system                     auto                    synced      none        none
 # needed for usb tethering
 /var/lib/misc                           auto                    persistent  transition  none
 # walinuxagent

--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -72,7 +72,7 @@
 /etc/network/if-up.d                    auto                    persistent  transition  none
 /etc/NetworkManager/system-connections  auto                    persistent  none        none
 # snappy security policy, etc
-/var/lib/snapd                         auto                    persistent  transition  none
+/var/lib/snapd                         auto                     synced      none        none
 # udev
 /etc/udev/rules.d                       auto                    persistent  transition  none
 # random seed
@@ -109,4 +109,6 @@
 /etc/default/swapfile                   auto                    persistent  transition  none
 # allow system wide proxy setting
 /etc/environment                        auto                    persistent  transition  none
+# https://github.com/snapcore/snapd/pull/3866
+/var/cache/snapd                         auto                   synced      none        none
 


### PR DESCRIPTION
http://manpages.ubuntu.com/manpages/xenial/man5/writable-paths.5.html

synced:
                 [ Any file appearing in the root filesystem will also be copied
                 over to writable storage. However file removals are still not
                 synced  and  files  existing  in both read-only and writeable
                 storage will not be updated. ]...

 transition:
                 [ ...note that subsequent boots
                 will ignore any new files appearing or  disappearing  in  the
                 original  read-only  rootfs  location  unless  you  perform a
                 factory reset. ]...