### PR TITLE
ubuntu-core-rootfs: deal with (broken) symlink in sync_dirs

### DIFF
--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -19,7 +19,7 @@ sync_dirs()
 	for file in "$source"/*
 	do
 		# Skip empty directories
-		[ ! -e "$base/$file" ] && continue
+		[ ! -e "$base/$file" -a ! -L "$base/$file" ] && continue
 
 		# If the target already exists as a file or link, there's nothing we can do
 		[ -e "$target/$file" -o -L "$target/$file" ] && [ ! -d "$target/$file" ] && continue


### PR DESCRIPTION
The sync_dirs() has a test -e that fails to take broken symlinks
into account. This means that symlinks that are broken when
sync_dir runs (which is a very special environment) are not
copied. This breaks e.g. the symlink snapd.snap-repair.timer
in /etc/systemd/system/timer-target.wants.

This is *not* tested yet, I'm still thinking about the best way to do this.