### PR TITLE
make /etc/update-motd.d writable for branding purposes

### DIFF
--- a/config/debian/changelog
+++ b/config/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-core-config (0.6.40+ppa48) UNRELEASED; urgency=medium
+ubuntu-core-config (0.6.40+ppa48) xenial; urgency=medium
 
   * make /etc/update-motd.d writable for branding purposes
 

--- a/config/debian/changelog
+++ b/config/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-config (0.6.40+ppa48) UNRELEASED; urgency=medium
+
+  * make /etc/update-motd.d writable for branding purposes
+
+ -- Oliver Grawert <ogra@ubuntu.com>  Fri, 19 Jan 2018 13:40:43 +0100
+
 ubuntu-core-config (0.6.40+ppa47) xenial; urgency=medium
 
   * switch /etc/systemd/system to "synced" mode

--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -111,4 +111,5 @@
 /etc/environment                        auto                    persistent  transition  none
 # https://github.com/snapcore/snapd/pull/3866
 /var/cache/snapd                         auto                   synced      none        none
-
+# make update-motd writable for branding purposes
+/etc/update-motd.d                      auto                    persistent  transition  none


### PR DESCRIPTION
For branding purposes of customers, /etc/update-motd.d needs to be be writable so customers can put extra bits into the login info of the message of the day that is shown right after ssh login.