### PR TITLE
config/etc/system-image/writable-paths: do not transition /snap 

### DIFF
--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -9,7 +9,7 @@
 # --------------------------------------------------------------------
 
 /home                                   user-data               persistent  transition  none
-/snap                                   auto                    persistent  transition  none
+/snap                                   auto                    persistent  none  none
 /tmp                                    none                    temporary   none        defaults
 /mnt                                    none                    temporary   none        defaults
 /media                                  none                    temporary   none        defaults

--- a/initramfs/debian/changelog
+++ b/initramfs/debian/changelog
@@ -1,6 +1,12 @@
+initramfs-tools-ubuntu-core (0.7.43+ppa24) xenial; urgency=medium
+
+  * ubuntu-core-rootfs: mount os/kernel snaps RO
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Mon, 11 Dec 2017 09:32:08 +0100
+
 initramfs-tools-ubuntu-core (0.7.43+ppa23) xenial; urgency=medium
 
-  * buntu-core-rootfs: deal with (broken) symlink in sync_dirs
+  * ubuntu-core-rootfs: deal with (broken) symlink in sync_dirs
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Thu, 14 Sep 2017 16:45:25 +0200
 


### PR DESCRIPTION
Newly build snaps have a "/snap" directory that contains some
metadata about the snap like "manifest.yaml" and "snapcraft.yaml".

The current writable-paths config sets /snap to transitional which
means that any files on the core snap under /snap will be copied
to the writable space. This is undesired, we just need an empty
/snap that is writable. This PR implements this.