### PR TITLE
scripts: add fixrtc-munt script to fix time issues on pi2,3

### DIFF
--- a/initramfs/scripts/local-bottom/fixrtc-mount
+++ b/initramfs/scripts/local-bottom/fixrtc-mount
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 # initramfs local-bottom script for fixrtc-mount
 
 PREREQ=""
@@ -53,3 +53,8 @@ if [ -n "$BROKEN_CLOCK" ]; then
                 echo "initrd: date set from $0 ($(date --utc))" > /dev/kmsg
         fi
 fi
+
+# This script is best-effort.  If we couldn't fudge the clock as desired,
+# just try to carry on boot anyway:
+# Boot will probably fail, but we won't have made the situation any worse
+exit 0

--- a/initramfs/scripts/local-bottom/fixrtc-mount
+++ b/initramfs/scripts/local-bottom/fixrtc-mount
@@ -39,7 +39,7 @@ if [ -n "$BROKEN_CLOCK" ]; then
         current=$(date +%s)
 
         # We start with date at the time of writing this
-        newdate=$(date -d "2017-06-09" +%s)
+        newdate=$(date -d "2017-07-26" +%s)
 
         if [ -d "$snapsfolder" ]; then
                 otherdate=$(stat -c %Y "$snapsfolder")

--- a/initramfs/scripts/local-bottom/fixrtc-mount
+++ b/initramfs/scripts/local-bottom/fixrtc-mount
@@ -1,0 +1,55 @@
+#!/bin/sh -e
+# initramfs local-bottom script for fixrtc-mount
+
+PREREQ=""
+
+# Output pre-requisites
+prereqs()
+{
+        echo "$PREREQ"
+}
+
+case "$1" in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+# This script looks at root file system files to get an accurate as possible
+# date. It runs when we already have a mounted root, as opposed to the 'fixrtc'
+# script, which uses the last mount time of the root file system. In devices
+# where there is no battery for the RTC, 'fixrtc' is not effective, as the mount
+# time will always be inaccurate. This script helps in those cases.
+
+BROKEN_CLOCK=""
+
+# shellcheck disable=SC2013
+for opt in $(cat /proc/cmdline); do
+        case ${opt} in
+        fixrtc)
+                BROKEN_CLOCK=1
+        ;;
+        esac
+done
+
+if [ -n "$BROKEN_CLOCK" ]; then
+        snapsfolder=/root/writable/system-data/var/lib/snapd/snaps
+
+        current=$(date +%s)
+
+        # We start with date at the time of writing this
+        newdate=$(date -d "2017-06-09" +%s)
+
+        if [ -d "$snapsfolder" ]; then
+                otherdate=$(stat -c %Y "$snapsfolder")
+                if [ "$otherdate" -gt "$newdate" ]; then
+                        newdate=$otherdate
+                fi
+        fi
+
+        if [ "$newdate" -gt "$current" ]; then
+                date -s "@$newdate"
+                echo "initrd: date set from $0 ($(date --utc))" > /dev/kmsg
+        fi
+fi

--- a/initramfs/scripts/local-bottom/fixrtc-mount
+++ b/initramfs/scripts/local-bottom/fixrtc-mount
@@ -39,7 +39,7 @@ if [ -n "$BROKEN_CLOCK" ]; then
         current=$(date +%s)
 
         # We start with date at the time of writing this
-        newdate=$(date -d "2017-07-26" +%s)
+        newdate=$(date -d "2018-07-26" +%s)
 
         if [ -d "$snapsfolder" ]; then
                 otherdate=$(stat -c %Y "$snapsfolder")


### PR DESCRIPTION
The fixrtc script we currently use to work around the issue that
the system clock in incorrect on a system without battery RTC
is not working well because the last mount time is never updated
on xenial systems.

This version of fixrtc-mount will look at the "snaps" directory
to get a more accurate estimate of the system time.

Thanks to Alfonso Sanchez-Beato for the script.