### PR TITLE
scripts/ubuntu-core/rootfs: fix mkdir error when the file exists

### DIFF
--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -116,7 +116,7 @@ handle_writable_paths()
                         # processed, as it will cause races.
                         case $1 in
                             /etc*)
-                                [ -d "${rootmnt}/writable/system-data/$1" ] || mkdir -p "${rootmnt}/writable/system-data/$1"
+                                [ -e "${rootmnt}/writable/system-data/$1" ] || mkdir -p "${rootmnt}/writable/system-data/$1"
                                 mount -o bind "${rootmnt}/writable/system-data/$1" "${rootmnt}/$1"
                                 ;;
                             *)


### PR DESCRIPTION
We have code in ubuntu-core-rootfs that processes all mounts in
/etc early. Part of it does a mkdir to create missing mount-points.

However some mounts in /etc are file-based bind mounts
(like /etc/hosts). For those the current code will try to
mkdir /etc/hosts but that fails because the file may exist already.

This PR fixes this error by checking for the existance of the
target only (the previous code was checking for the directory).