### PR TITLE
initramfs: fix shellchecks on bionic

### DIFF
--- a/initramfs/hooks/resize
+++ b/initramfs/hooks/resize
@@ -17,6 +17,7 @@ case "$1" in
         ;;
 esac
 
+# shellcheck disable=SC1091
 . /usr/share/initramfs-tools/hook-functions
 
 copy_exec /sbin/parted /sbin

--- a/initramfs/hooks/ubuntu-core-rootfs
+++ b/initramfs/hooks/ubuntu-core-rootfs
@@ -17,6 +17,7 @@ case "$1" in
         ;;
 esac
 
+# shellcheck disable=SC1091
 . /usr/share/initramfs-tools/hook-functions
 
 copy_exec /bin/chown


### PR DESCRIPTION
Shellcheck on bionic is a bit more strict than on xenial. This should fix the current build failure on bionic of initramfs-tools-ubuntu-core.