### PR TITLE
ubuntu-core-rootfs: fix typo in error message

### DIFF
--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -212,10 +212,10 @@ mountroot()
 
         # basic validation
         if [ -z "$snap_core" ]; then
-            panic "the requried kernel commandline snap_core is not set"
+            panic "the required kernel commandline snap_core is not set"
         fi
         if [ -z "$snap_kernel" ]; then
-            panic "the requried kernel commandline snap_kernel is not set"
+            panic "the required kernel commandline snap_kernel is not set"
         fi
 
         # always ensure writable is in a good state


### PR DESCRIPTION
Trivial typo fix: s/requried/required/ in mountroot error messages.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
