### PR TITLE
initramfs: fix delays in installed system boot

### DIFF
--- a/initramfs/scripts/ubuntu-core-functions
+++ b/initramfs/scripts/ubuntu-core-functions
@@ -15,9 +15,9 @@ get_partition_from_label()
 
 	[ -n "$label" ] || panic "need FS label"
 
-	# spike: device node is predictable if ubuntu-data is encrypted. Also
+	# FIXME: we're handling only the encrypted data case.
+	# The device node is predictable if ubuntu-data is encrypted. Also
 	# wait-for-root fails in this case, so use a shortcut here.
-        sleep 5
 	if [ "$label" = "ubuntu-data" ]; then
 		echo "/dev/mapper/ubuntu-data"
 		return

--- a/initramfs/scripts/ubuntu-core-functions
+++ b/initramfs/scripts/ubuntu-core-functions
@@ -15,6 +15,14 @@ get_partition_from_label()
 
 	[ -n "$label" ] || panic "need FS label"
 
+	# spike: device node is predictable if ubuntu-data is encrypted. Also
+	# wait-for-root fails in this case, so use a shortcut here.
+        sleep 5
+	if [ "$label" = "ubuntu-data" ]; then
+		echo "/dev/mapper/ubuntu-data"
+		return
+	fi
+
 	# Make sure the device has been created by udev before looking for it
 	# Don't need to panic, since the output will be validated outside this function
 	wait-for-root "LABEL=$label" "${ROOTDELAY:-180}" >/dev/null || true
@@ -54,8 +62,6 @@ do_root_mounting()
 	fi
 
 	# mount writable rw
-	#path=$(get_partition_from_label "$writable_label")
-	# FIXME: we're handling only the encrypted data case
-	path=/dev/mapper/ubuntu-data
+	path=$(get_partition_from_label "$writable_label")
 	mount "$path" "$writable_mnt"
 }

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -188,15 +188,7 @@ mount_snaps()
 
 open_data_partition()
 {
-        # don't remove this sleep
-        sleep 1
-        modprobe dm-crypt
-        modprobe aes-x86_64
-        modprobe cryptd
-        modprobe crypto_simd
-        modprobe glue_helper
-        modprobe af_alg
-        modprobe algif_skcipher
+        mkdir /run/cryptsetup
         tmpboot_mnt="/tmpmnt_system-boot"
         mkdir -p $tmpboot_mnt
         mount -o ro "$boot_partition" "$tmpboot_mnt"


### PR DESCRIPTION
Don't call wait-for-root on device-mapped ubuntu-data to prevent random
delays during the boot process, and remove previous workarounds and
debug code.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>