### PR TITLE
initramfs: remove misplaced umount

### DIFF
--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -93,7 +93,5 @@ snaps_path="/system-data/var/lib/snapd/snaps"
 create_writable_on_tmpfs
 update_grub
 
-umount /writable
-
 sync
 


### PR DESCRIPTION
When in install and recover modes we don't want to unmount the ubuntu-data
tmpfs in initramfs (it worked because the filesystem was in use and the
umount command failed).

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>