### PR TITLE
initramfs: open luks device using the master key

### DIFF
--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -192,7 +192,7 @@ open_data_partition()
         tmpboot_mnt="/tmpmnt_system-boot"
         mkdir -p $tmpboot_mnt
         mount -o ro "$boot_partition" "$tmpboot_mnt"
-        LD_PRELOAD=/lib/no-udev.so cryptsetup --type luks2 --key-file "$tmpboot_mnt/keyfile" --pbkdf-memory 100000 open /dev/sda4 ubuntu-data
+        LD_PRELOAD=/lib/no-udev.so cryptsetup open --type luks2 --master-key-file "$tmpboot_mnt/keyfile" /dev/sda4 ubuntu-data
         umount "$tmpboot_mnt"
         ln -s ../dm-0 /dev/mapper/ubuntu-data
 }

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -194,7 +194,6 @@ open_data_partition()
         mount -o ro "$boot_partition" "$tmpboot_mnt"
         LD_PRELOAD=/lib/no-udev.so cryptsetup open --type luks2 --master-key-file "$tmpboot_mnt/keyfile" /dev/sda4 ubuntu-data
         umount "$tmpboot_mnt"
-        ln -s ../dm-0 /dev/mapper/ubuntu-data
 }
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
Change LUKS device operations to use the master key directly.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>