### PR TITLE
initramfs: unseal luks master key

### DIFF
--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -192,7 +192,7 @@ open_data_partition()
         tmpboot_mnt="/tmpmnt_system-boot"
         mkdir -p $tmpboot_mnt
         mount -o ro "$boot_partition" "$tmpboot_mnt"
-        LD_PRELOAD=/lib/no-udev.so cryptsetup open --type luks2 --master-key-file "$tmpboot_mnt/keyfile" /dev/sda4 ubuntu-data
+        unlock --key-path "$tmpboot_mnt/keyfile" /dev/sda4 ubuntu-data
         umount "$tmpboot_mnt"
 }
 


### PR DESCRIPTION
The master key to the LUKS device containing ubuntu-data is now sealed
to the TPM at installation time. Unseal the key to open the device and
allow access to the data within.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>