### PR TITLE
initramfs: restore wait-for-root calls

### DIFF
--- a/initramfs/scripts/ubuntu-core-functions
+++ b/initramfs/scripts/ubuntu-core-functions
@@ -15,14 +15,6 @@ get_partition_from_label()
 
 	[ -n "$label" ] || panic "need FS label"
 
-	# FIXME: we're handling only the encrypted data case.
-	# The device node is predictable if ubuntu-data is encrypted. Also
-	# wait-for-root fails in this case, so use a shortcut here.
-	if [ "$label" = "ubuntu-data" ]; then
-		echo "/dev/mapper/ubuntu-data"
-		return
-	fi
-
 	# Make sure the device has been created by udev before looking for it
 	# Don't need to panic, since the output will be validated outside this function
 	wait-for-root "LABEL=$label" "${ROOTDELAY:-180}" >/dev/null || true
@@ -39,7 +31,7 @@ do_root_mounting()
 	root="LABEL=$writable_label"
 
 	# Make sure the device has been created by udev before we try to mount
-	#wait-for-root "$root" "${ROOTDELAY:-180}" || panic "unable to find root partition '$root'"
+	wait-for-root "$root" "${ROOTDELAY:-180}" || panic "unable to find root partition '$root'"
 
 	# FIXME: This is never false since we set $root above
 	[ -n "$root" ] || panic "no root partition specified"

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -250,6 +250,10 @@ mountroot()
         if [ "$snap_mode" = "install" ] || [ "$snap_mode" = "recover" ]; then
             writable_mnt="/writable"
         else
+            # FIXME: we need this to create /dev/disk/by-label/ubuntu-data used by wait-for-root
+            udevadm control --property DM_UDEV_PRIMARY_SOURCE_FLAG=1
+            udevadm trigger /dev/dm-0
+
             writable_mnt="/tmpmnt_${writable_label}"
 	    mkdir -p "$writable_mnt"
             fsck_writable "$writable_label" "$writable_mnt"

--- a/initramfs/testing/aaa-tests.py
+++ b/initramfs/testing/aaa-tests.py
@@ -131,8 +131,7 @@ class UbuntuCoreFunctionsTests(VMShellTestCase):
         self.assertEqual(returncode, 150)
         self.assertEqual(log, [])
         self.assertEqual(self.sh_mocked_calls(), [
-            # FIXME: re-enable after solving udev issues in spike
-            #("wait-for-root", "LABEL=", "180"),
+            ("wait-for-root", "LABEL=", "180"),
             ("panic", "root device  does not exist"),
         ])
 
@@ -144,10 +143,8 @@ class UbuntuCoreFunctionsTests(VMShellTestCase):
         self.assertEqual(returncode, 150)
         self.assertEqual(log, [])
         self.assertEqual(self.sh_mocked_calls(), [
-            # FIXME: re-enable after solving udev issues in spike
-            #("wait-for-root", "LABEL=some-label", "180"),
-            #("panic", "unable to find root partition LABEL=some-label"),
-            ("panic", "root device  does not exist"),
+            ("wait-for-root", "LABEL=some-label", "180"),
+            ("panic", "unable to find root partition LABEL=some-label"),
         ])
 
     def test_do_root_mounting__works(self) -> None:
@@ -162,8 +159,7 @@ class UbuntuCoreFunctionsTests(VMShellTestCase):
         self.assertEqual(returncode, 0)
         self.assertEqual(log, [])
         self.assertEqual(self.sh_mocked_calls(), [
-            # FIXME: re-enable after solving udev issues in spike
-            #("wait-for-root", "LABEL=some-label", "180"),
+            ("wait-for-root", "LABEL=some-label", "180"),
             ("findfs", "LABEL=some-label"),
             ("modprobe", "squashfs"),
             ("wait-for-root", "LABEL=some-label", "180"),


### PR DESCRIPTION
Uncomment wait-for-root calls and create /dev/disk/by-label/ubuntu-data
instead by triggering udev. This manual trigger shouldn't be necessary,
so we still need to know what is happening.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>