### PR TITLE
initramfs: check keypress in run mode

### DIFF
--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -34,6 +34,9 @@ done
 # Only prepare writable on tmpfs in these three modes
 
 if [ "$snap_mode" != "install" ] && [ "$snap_mode" != "recover" ]; then
+    # run mode
+    # TODO: add recovery handling
+    chooser -seed /ubuntu-seed -output "$output_file" -check
     exit 0
 fi
 


### PR DESCRIPTION
When booting in run mode, check if our magic key has been pressed
and execute some other action in this case.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>