### PR TITLE
Use /var/lib/snapd/seed/snaps/ as fallback when mounting core and kernel

### DIFF
--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -168,13 +168,23 @@ fsck_writable()
 # Mount core and kernel snaps
 mount_snaps()
 {
+		core_snap_path="${writable_mnt}/system-data/var/lib/snapd/snaps/${snap_core}"
         # mount OS snap
-        mount -o ro "${writable_mnt}/system-data/var/lib/snapd/snaps/${snap_core}" "$rootmnt"
+		if [ ! -e "${core_snap_path}" ]; then
+		    # fallback
+			core_snap_path="${writable_mnt}/system-data/var/lib/snapd/seed/snaps/${snap_core}"
+		fi
+		mount -o ro "${core_snap_path}" "$rootmnt"
 
         # now add a kernel bind mounts to it
         local kernel_mnt="/tmpmnt_kernel"
         mkdir -p "$kernel_mnt"
-        mount -o ro "${writable_mnt}/system-data/var/lib/snapd/snaps/${snap_kernel}" "$kernel_mnt"
+		kernel_snap_path="${writable_mnt}/system-data/var/lib/snapd/snaps/${snap_kernel}"
+		if [ ! -e "${kernel_snap_path}" ]; then
+			# fallback
+			kernel_snap_path="${writable_mnt}/system-data/var/lib/snapd/seed/snaps/${snap_kernel}"
+		fi
+		mount -o ro "${kernel_snap_path}" "$kernel_mnt"
         for d in modules firmware; do
             if [ -d "${kernel_mnt}/$d" ]; then
                 mount -o bind "${kernel_mnt}/$d" "$rootmnt/lib/$d"


### PR DESCRIPTION
Use `/var/lib/snapd/seed/snaps/` as fallback when mounting core and kernel if the expected snaps are not present in  `/var/lib/snapd/snaps`. This is to address first-boot edge case as this:

pre-conditions:
- ubuntu core image has a broken gadget snap in `seeds/` (in fact any broken snap should do as well), e.g. with malformed `gadget.yaml` and is booted for the first time.
- the image has symlinks for kernel and core from `seeds/` to `var/lib/snapd/snaps`, as is the case with fresh images created with `ubuntu-image`.

The scenario:

1. the image is booted and seeding starts.
2. broken gadget fails to install during seeding.
3. seeding is undone for all seeded snaps.
4. as part of 'undo', snapd removes .snap files from `/var/lib/snapd/snaps/`, including symlinks to kernel and core (as far as I can tell this is done in `undoMountSnap()` in snapd), so if the system is now reboted, initrd will not find kernel and core anymore.

I've two possible fixes on snapd side in mind to discuss, but in the meantime the proposed PR should provide initrd with a fallback, however:
**DISCLAIMER**: I wasn't able to test the proposed fix and need some help with that, having this fix as part of custom kernel snap (that I re-packed with patched initrd, and side-loaded via `--snap` when creating the image) is not really testable, because the kernel needs to be in `/var/lib/snapd/snaps/*.snap` for my new `initrd` to take effect, so if I provoke the failing scenario, it will not be there. I'm unclear how the boot process works, does the fix need to go to the initrd present in `/boot/initrd-core.img` on core as well?
