### PR TITLE
initramfs: get snap parameters from grubenv

### DIFF
--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -23,10 +23,6 @@ for x in $(cat /proc/cmdline); do
         snap_mode=*)
             snap_mode=${x#*=}
             ;;
-        snap_recovery_system=*)
-            recovery=${x#*=}
-            echo "System recovery set to $recovery"
-            ;;
     esac
 done
 
@@ -41,6 +37,13 @@ seed_grubenv_set() {
 
 ubuntu_seed_part="$(findfs LABEL=ubuntu-seed || true)"
 ubuntu_boot_part="$(findfs LABEL=ubuntu-boot || true)"
+
+mkdir /ubuntu-seed /ubuntu-boot
+mount -t vfat "$ubuntu_seed_part" /ubuntu-seed
+mount -t vfat "$ubuntu_boot_part" /ubuntu-boot
+recovery=$(seed_grubenv_get "snap_recovery_system")
+echo "System recovery set to $recovery"
+
 recovery_root="/ubuntu-seed/"
 recovery_path="$recovery_root/systems/$recovery"
 system_path="/system-data"
@@ -50,9 +53,6 @@ chooser_output_file="/chooser.out"
 
 
 check_recover_trigger() {
-    mkdir /ubuntu-seed /ubuntu-boot
-    mount -t vfat "$ubuntu_seed_part" /ubuntu-seed
-    mount -t vfat "$ubuntu_boot_part" /ubuntu-boot
 
     if [ -z "$snap_mode" ]; then
         # run mode
@@ -135,17 +135,12 @@ update_grub() {
     grub-editenv "$system_boot_grubenv" create
     grub-editenv "$system_boot_grubenv" set snap_core="core20_x1.snap"
     grub-editenv "$system_boot_grubenv" set snap_kernel="pc-kernel_x1.snap"
-
-    umount /ubuntu-seed
-    umount /ubuntu-boot
 }
 
 check_recover_trigger
 
 # Only prepare writable on tmpfs in these modes
 if [ "$snap_mode" != "install" ] && [ "$snap_mode" != "recover" ]; then
-    umount /ubuntu-seed
-    umount /ubuntu-boot
     exit
 fi
 

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -8,6 +8,10 @@
 . /scripts/ubuntu-core-functions
 
 
+seed_grubenv_get() {
+    grub-editenv /ubuntu-seed/EFI/ubuntu/grubenv list|grep -w "$1"|cut -d= -f2
+}
+
 sync_dirs()
 {
 	base="$1"
@@ -211,13 +215,6 @@ mountroot()
         # find what snappy-os version to use
         for x in $(cat /proc/cmdline); do
 	    case "${x}" in
-                # new kernel/os snap vars
-		snap_core=*)
-			snap_core="${x#*=}"
-			;;
-		snap_kernel=*)
-			snap_kernel="${x#*=}"
-			;;
                 snap_mode=*)
 			snap_mode="${x#*=}"
 			;;
@@ -228,18 +225,31 @@ mountroot()
             snap_mode=recover
         fi
 
+        snap_core=$(seed_grubenv_get "snap_core")
+        snap_kernel=$(seed_grubenv_get "snap_kernel")
+
+        echo =============================
+        echo cmdline: $(cat /proc/cmdline)
+        echo snap_mode: $snap_mode
+        echo snap_core: $snap_core
+        echo snap_kernel: $snap_kernel
+        echo =============================
+
+        umount /ubuntu-seed
+        umount /ubuntu-boot
+
         if [ "$snap_mode" = "install" ] || [ "$snap_mode" = "recover" ]; then
-            # FIXME: these should come from the kernel cmdline
+            # FIXME: these should come from grubenv
             snap_core="core20_x1.snap"
             snap_kernel="pc-kernel_x1.snap"
         fi
 
         # basic validation
         if [ -z "$snap_core" ]; then
-            panic "the requried kernel commandline snap_core is not set"
+            panic "the required grubenv variable snap_core is not set"
         fi
         if [ -z "$snap_kernel" ]; then
-            panic "the requried kernel commandline snap_kernel is not set"
+            panic "the required grubenv variable snap_kernel is not set"
         fi
 
 	# Request bootloader partition be mounted


### PR DESCRIPTION
To make TPM policy generation easier, remove snap parameters such as
snap_core and snap_kernel from the kernel command line and read
them directly from the grub environment file.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>