### PR TITLE
initramfs: update run mode variable name

### DIFF
--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -20,8 +20,8 @@ esac
 # shellcheck disable=SC2013
 for x in $(cat /proc/cmdline); do
     case $x in
-        snap_mode=*)
-            snap_mode=${x#*=}
+        snap_recovery_mode=*)
+            snap_recovery_mode=${x#*=}
             ;;
     esac
 done
@@ -54,14 +54,14 @@ chooser_output_file="/chooser.out"
 
 check_recover_trigger() {
 
-    if [ -z "$snap_mode" ]; then
+    if [ -z "$snap_recovery_mode" ]; then
         # run mode
         echo Press SHIFT to enter recover mode
         sleep 2
         if /bin/check-trigger; then
             chooser -title "Select the recovery system version:" -seed /ubuntu-seed -output "$chooser_output_file"
             touch /.recover
-            snap_mode="recover"
+            snap_recovery_mode="recover"
             current_version="$(seed_grubenv_get snap_recovery_system)"
             # shellcheck disable=SC1090
             . "$chooser_output_file"
@@ -70,7 +70,7 @@ check_recover_trigger() {
                 # FIXME: also tell the bootloader to boot kernel-next for recovery if using current/next
                 #        to prevent open-value parameters in the kernel command line
                 seed_grubenv_set snap_recovery_system="$uc_recovery_system"
-                seed_grubenv_set snap_mode="recover"
+                seed_grubenv_set snap_recovery_mode="recover"
                 extract_kernel "$uc_recovery_system"
                 echo "Rebooting to use recovery version $uc_recovery_system"
                 sleep 2
@@ -100,7 +100,7 @@ create_writable_partition_on_tmpfs() {
 }
 
 run_chooser() {
-    if [ "$snap_mode" = "install" ]; then
+    if [ "$snap_recovery_mode" = "install" ]; then
         chooser -title "Select the recovery version to install:" -seed /ubuntu-seed -output "$chooser_output_file"
     fi
 }
@@ -140,7 +140,7 @@ update_grub() {
 check_recover_trigger
 
 # Only prepare writable on tmpfs in these modes
-if [ "$snap_mode" != "install" ] && [ "$snap_mode" != "recover" ]; then
+if [ "$snap_recovery_mode" != "install" ] && [ "$snap_recovery_mode" != "recover" ]; then
     exit
 fi
 

--- a/initramfs/scripts/local-premount/install
+++ b/initramfs/scripts/local-premount/install
@@ -23,10 +23,6 @@ for x in $(cat /proc/cmdline); do
         snap_mode=*)
             snap_mode=${x#*=}
             ;;
-        snap_recovery_system=*)
-            recovery=${x#*=}
-            echo "System recovery set to $recovery"
-            ;;
     esac
 done
 
@@ -41,6 +37,13 @@ seed_grubenv_set() {
 
 ubuntu_seed_part="$(findfs LABEL=ubuntu-seed || true)"
 ubuntu_boot_part="$(findfs LABEL=ubuntu-boot || true)"
+
+mkdir /ubuntu-seed /ubuntu-boot
+mount -t vfat "$ubuntu_seed_part" /ubuntu-seed
+mount -t vfat "$ubuntu_boot_part" /ubuntu-boot
+recovery=$(seed_grubenv_get "snap_recovery_system")
+echo "System recovery set to $recovery"
+
 recovery_root="/ubuntu-seed/"
 recovery_path="$recovery_root/systems/$recovery"
 system_path="/system-data"
@@ -50,9 +53,6 @@ chooser_output_file="/chooser.out"
 
 
 check_recover_trigger() {
-    mkdir /ubuntu-seed /ubuntu-boot
-    mount -t vfat "$ubuntu_seed_part" /ubuntu-seed
-    mount -t vfat "$ubuntu_boot_part" /ubuntu-boot
 
     if [ -z "$snap_mode" ]; then
         # run mode
@@ -135,17 +135,12 @@ update_grub() {
     grub-editenv "$system_boot_grubenv" create
     grub-editenv "$system_boot_grubenv" set snap_core="core20_x1.snap"
     grub-editenv "$system_boot_grubenv" set snap_kernel="pc-kernel_x1.snap"
-
-    umount /ubuntu-seed
-    umount /ubuntu-boot
 }
 
 check_recover_trigger
 
 # Only prepare writable on tmpfs in these modes
 if [ "$snap_mode" != "install" ] && [ "$snap_mode" != "recover" ]; then
-    umount /ubuntu-seed
-    umount /ubuntu-boot
     exit
 fi
 

--- a/initramfs/scripts/local-premount/resize
+++ b/initramfs/scripts/local-premount/resize
@@ -17,9 +17,9 @@ case "$1" in
 esac
 
 # Don't run in install mode
-grep -wq "snap_mode=install" /proc/cmdline && exit 0
+grep -wq "snap_recovery_mode=install" /proc/cmdline && exit 0
 
-# FIXME: temporarily disable writable resize
+# FIXME: disable writable resize, create the partition with right size on install
 echo "not resizing"
 sleep 2
 exit 0

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -215,14 +215,14 @@ mountroot()
         # find what snappy-os version to use
         for x in $(cat /proc/cmdline); do
 	    case "${x}" in
-                snap_mode=*)
-			snap_mode="${x#*=}"
+                snap_recovery_mode=*)
+			snap_recovery_mode="${x#*=}"
 			;;
 		esac
 	done
 
         if [ -f /.recover ]; then
-            snap_mode=recover
+            snap_recovery_mode=recover
         fi
 
         snap_core=$(seed_grubenv_get "snap_core")
@@ -230,16 +230,14 @@ mountroot()
 
         echo =============================
         echo cmdline: $(cat /proc/cmdline)
-        echo snap_mode: $snap_mode
-        echo snap_core: $snap_core
-        echo snap_kernel: $snap_kernel
+        grub-editenv /ubuntu-seed/EFI/ubuntu/grubenv list
         echo =============================
 
         umount /ubuntu-seed
         umount /ubuntu-boot
 
-        if [ "$snap_mode" = "install" ] || [ "$snap_mode" = "recover" ]; then
-            # FIXME: these should come from grubenv
+        if [ "$snap_recovery_mode" = "install" ] || [ "$snap_recovery_mode" = "recover" ]; then
+            # FIXME: these should come from grubenv or inferred from snap_recovery_system
             snap_core="core20_x1.snap"
             snap_kernel="pc-kernel_x1.snap"
         fi
@@ -255,14 +253,14 @@ mountroot()
 	# Request bootloader partition be mounted
 	boot_partition=$(findfs LABEL="ubuntu-boot" 2>/dev/null || :)
 
-        if [ "$snap_mode" != "install" ]; then
+        if [ "$snap_recovery_mode" != "install" ]; then
             open_data_partition
         fi
 
         # always ensure writable is in a good state
         writable_label="ubuntu-data"
 
-        if [ "$snap_mode" = "install" ] || [ "$snap_mode" = "recover" ]; then
+        if [ "$snap_recovery_mode" = "install" ] || [ "$snap_recovery_mode" = "recover" ]; then
             writable_mnt="/writable"
         else
             # FIXME: we need this to create /dev/disk/by-label/ubuntu-data used by wait-for-root
@@ -354,7 +352,7 @@ mountroot()
                 androiddir="writable/androidboot"
                 mkdir -p "${rootmnt}/${androiddir}"
                 if [ ! -e "${rootmnt}/${androiddir}/androidboot.env" ]; then
-                        echo -e "snap_mode=\nsnap_core=$snap_core\nsnap_kernel=$snap_kernel\nsnap_try_core=\nsnap_try_kernel=" > \
+                        echo -e "snap_recovery_mode=\nsnap_core=$snap_core\nsnap_kernel=$snap_kernel\nsnap_try_core=\nsnap_try_kernel=" > \
                              "${rootmnt}/${androiddir}/androidboot.env"
                 fi
                 mount -o bind "${rootmnt}/${androiddir}" "${rootmnt}/boot/androidboot"
@@ -384,7 +382,7 @@ mountroot()
 	done
 
         # Propagate the recover marker
-        [ -f /.recover] && mv /.recover "${rootmnt}/writable/system-data/"
+        [ -f /.recover ] && mv /.recover "${rootmnt}/writable/system-data/"
         [ -f /chooser.out ] && mv /chooser.out "${rootmnt}/writable/system-data/"
 
 	[ "$quiet" != "y" ] && log_begin_msg "Running /scripts/local-bottom"

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -8,6 +8,10 @@
 . /scripts/ubuntu-core-functions
 
 
+seed_grubenv_get() {
+    grub-editenv /ubuntu-seed/EFI/ubuntu/grubenv list|grep -w "$1"|cut -d= -f2
+}
+
 sync_dirs()
 {
 	base="$1"
@@ -211,13 +215,6 @@ mountroot()
         # find what snappy-os version to use
         for x in $(cat /proc/cmdline); do
 	    case "${x}" in
-                # new kernel/os snap vars
-		snap_core=*)
-			snap_core="${x#*=}"
-			;;
-		snap_kernel=*)
-			snap_kernel="${x#*=}"
-			;;
                 snap_mode=*)
 			snap_mode="${x#*=}"
 			;;
@@ -228,18 +225,31 @@ mountroot()
             snap_mode=recover
         fi
 
+        snap_core=$(seed_grubenv_get "snap_core")
+        snap_kernel=$(seed_grubenv_get "snap_kernel")
+
+        echo =============================
+        echo cmdline: $(cat /proc/cmdline)
+        echo snap_mode: $snap_mode
+        echo snap_core: $snap_core
+        echo snap_kernel: $snap_kernel
+        echo =============================
+
+        umount /ubuntu-seed
+        umount /ubuntu-boot
+
         if [ "$snap_mode" = "install" ] || [ "$snap_mode" = "recover" ]; then
-            # FIXME: these should come from the kernel cmdline
+            # FIXME: these should come from grubenv
             snap_core="core20_x1.snap"
             snap_kernel="pc-kernel_x1.snap"
         fi
 
         # basic validation
         if [ -z "$snap_core" ]; then
-            panic "the requried kernel commandline snap_core is not set"
+            panic "the required grubenv variable snap_core is not set"
         fi
         if [ -z "$snap_kernel" ]; then
-            panic "the requried kernel commandline snap_kernel is not set"
+            panic "the required grubenv variable snap_kernel is not set"
         fi
 
 	# Request bootloader partition be mounted


### PR DESCRIPTION
Use snap_recovery_mode to hold the run mode and reserve snap_mode for
the try, trying modes.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>
