### PR TITLE
initramfs: update unlock keyfile parameter

### DIFF
--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -197,7 +197,7 @@ open_data_partition()
         tmpboot_mnt="/tmpmnt_system-boot"
         mkdir -p $tmpboot_mnt
         mount -o ro "$boot_partition" "$tmpboot_mnt"
-        unlock --key-path "$tmpboot_mnt/keyfile" /dev/sda4 ubuntu-data
+        unlock --key-file "$tmpboot_mnt/keyfile" /dev/sda4 ubuntu-data
         umount "$tmpboot_mnt"
 }
 


### PR DESCRIPTION
Update initramfs to call the ubuntu-core-fde-utils unlock utility with
the new parameters from policy-work-3.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>