### PR TITLE
writable-paths: enable create writable /etc/systemd/user

### DIFF
--- a/config/etc/system-image/writable-paths
+++ b/config/etc/system-image/writable-paths
@@ -57,6 +57,7 @@
 /var/lib/initramfs-tools                auto                    persistent  transition  none
 # systemd
 /etc/systemd/system                     auto                    synced      none        none
+/etc/systemd/user                       auto                    synced      none        none
 # needed for usb tethering
 /var/lib/misc                           auto                    persistent  transition  none
 # walinuxagent


### PR DESCRIPTION
When snapd is installed on a UC16 system it will try to create
files in /etc/systemd/user for the snapd user session agent.

This directory is currently not writable and this PR fixes
this so that we can (eventually) install snapd on UC16.