### PR TITLE
initramfs: add neccessary modules for rockchip emmc and sdcard

### DIFF
--- a/initramfs/modules/modules.arm64
+++ b/initramfs/modules/modules.arm64
@@ -1,2 +1,14 @@
-usb-storage
+dw_mmc
+dw_mmc-pltfm
+dw_mmc-rockchip
+fixed
+i2c-rk3x
 nls_iso8859-1
+phy-rockchip-emmc
+rk808
+rk808-regulator
+rockchip-io-domain
+sdhci
+sdhci-of-arasan
+sdhci-pltfm
+usb-storage

--- a/initramfs/modules/modules.armhf
+++ b/initramfs/modules/modules.armhf
@@ -1,2 +1,14 @@
-usb-storage
+dw_mmc
+dw_mmc-pltfm
+dw_mmc-rockchip
+fixed
+i2c-rk3x
 nls_iso8859-1
+phy-rockchip-emmc
+rk808
+rk808-regulator
+rockchip-io-domain
+sdhci
+sdhci-of-arasan
+sdhci-pltfm
+usb-storage


### PR DESCRIPTION
These modules are needed for emmc and sdcard booting on rk3399.

Tested on rk3399-sapphire-excavator.

Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>