### PR TITLE
initramfs: add new handle_writable_defaults()

### DIFF
--- a/initramfs/Makefile
+++ b/initramfs/Makefile
@@ -6,7 +6,7 @@ check:
 	@set -e; for f in $(TESTFILES); do \
 	    echo "Checking shell syntax of $$f"; \
 	    sh -n $$f; \
-            shellcheck -x $$f; \
+            shellcheck $$f; \
 	done
 
 	@set -e; for f in tests/*.sh; do \

--- a/initramfs/Makefile
+++ b/initramfs/Makefile
@@ -6,6 +6,10 @@ check:
 	@set -e; for f in $(TESTFILES); do \
 	    echo "Checking shell syntax of $$f"; \
 	    sh -n $$f; \
-            shellcheck $$f; \
+            shellcheck -x $$f; \
 	done
 
+	@set -e; for f in tests/*.sh; do \
+		echo "Running tests $$f"; \
+		sh -e $$f; \
+	done;

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -153,7 +153,7 @@ handle_writable_defaults()
             [ ! -e "$fileordir" ] && continue
 
             # copy
-            cp -a $fileordir "$dstpath"
+            cp -a "$fileordir" "$dstpath"
         done
         touch "$srcpath/.done"
 }

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -132,6 +132,23 @@ handle_writable_paths()
 			continue
 		fi
 	done
+
+        # now apply the defaults on top
+        handle_writable_defaults
+}
+
+# handle_writable_default will apply system defaults *once* after
+# the handle_writable_path got populated
+handle_writable_defaults()
+{
+        srcpath="${rootmnt}/writable/system-data/_writable_defaults"
+        if [ ! -d "$srcpath" ] || [ -e "${srcpath}/.done" ]; then
+                return
+        fi
+
+        dstpath="${rootmnt}/writable/system-data"
+        cp -a "$srcpath/*" "$dstpath"
+        touch "$srcpath/.done"
 }
 
 fsck_writable()

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -150,7 +150,7 @@ handle_writable_defaults()
         dstpath="${rootmnt}/writable/system-data"
         for fileordir in "$srcpath"/* ; do
             # skip empty $srcpath/
-            [ ! -e "$fileordir" ] && continue
+            [ ! -e "$fileordir" ] && [ ! -L "$fileordir" ] &&  continue
 
             # copy
             cp -a "$fileordir" "$dstpath"

--- a/initramfs/scripts/ubuntu-core-rootfs
+++ b/initramfs/scripts/ubuntu-core-rootfs
@@ -5,7 +5,8 @@
 # Entry point: mountroot().
 #---------------------------------------------------------------------
 
-. /scripts/ubuntu-core-functions
+# shellcheck disable=SC2034
+. ${scriptsroot:-/scripts}/ubuntu-core-functions
 
 sync_dirs()
 {
@@ -147,7 +148,13 @@ handle_writable_defaults()
         fi
 
         dstpath="${rootmnt}/writable/system-data"
-        cp -a "$srcpath/*" "$dstpath"
+        for fileordir in "$srcpath"/* ; do
+            # skip empty $srcpath/
+            [ ! -e "$fileordir" ] && continue
+
+            # copy
+            cp -a $fileordir "$dstpath"
+        done
         touch "$srcpath/.done"
 }
 

--- a/initramfs/tests/test_ubuntu-core-rootfs.sh
+++ b/initramfs/tests/test_ubuntu-core-rootfs.sh
@@ -1,7 +1,8 @@
 #!/bin/sh -e
 
+# shellcheck disable=SC2034
 scriptsroot=./scripts
-# shellcheck source=./scripts/ubuntu-core-rootfs
+# shellcheck disable=SC1091
 . scripts/ubuntu-core-rootfs
 
 

--- a/initramfs/tests/test_ubuntu-core-rootfs.sh
+++ b/initramfs/tests/test_ubuntu-core-rootfs.sh
@@ -1,0 +1,34 @@
+#!/bin/sh -e
+
+scriptsroot=./scripts
+# shellcheck source=./scripts/ubuntu-core-rootfs
+. scripts/ubuntu-core-rootfs
+
+
+rootmnt="$(mktemp -d)"
+trap 'rm -rf "$rootmnt"' EXIT
+
+# test: no _writable_defaults does not break
+mkdir -p "$rootmnt/writeable/system-data/"
+handle_writable_defaults
+
+# test: empty _writable_defaults does not break
+mkdir -p "$rootmnt/writable/system-data/_writable_defaults"
+handle_writable_defaults
+test -e "$rootmnt/writable/system-data/_writable_defaults/.done"
+# cleanup
+rm -f "$rootmnt/writable/system-data/_writable_defaults/.done"
+
+# test: file/dir in _writable_defaults
+mkdir -p "$rootmnt/writable/system-data/_writable_defaults/some-dir"
+touch "$rootmnt/writable/system-data/_writable_defaults/some-dir/some-file"
+touch "$rootmnt/writable/system-data/_writable_defaults/other-file"
+
+handle_writable_defaults
+# ensure we have the .done file
+test -e "$rootmnt/writable/system-data/_writable_defaults/.done"
+test -d "$rootmnt/writable/system-data/some-dir"
+test -e "$rootmnt/writable/system-data/some-dir/some-file"
+test -e "$rootmnt/writable/system-data/other-file"
+# cleanup
+rm -f "$rootmnt/writable/system-data/_writable_defaults/.done"

--- a/initramfs/tests/test_ubuntu-core-rootfs.sh
+++ b/initramfs/tests/test_ubuntu-core-rootfs.sh
@@ -12,24 +12,37 @@ trap 'rm -rf "$rootmnt"' EXIT
 # test: no _writable_defaults does not break
 mkdir -p "$rootmnt/writeable/system-data/"
 handle_writable_defaults
+echo "Testing no _writable_defaults does not break anything"
 
 # test: empty _writable_defaults does not break
 mkdir -p "$rootmnt/writable/system-data/_writable_defaults"
 handle_writable_defaults
+echo "Testing empty _writable_defaults does not break anything"
+set -x
 test -e "$rootmnt/writable/system-data/_writable_defaults/.done"
+# 3 because: "system-data", "system-data/_writable_defaults", "s-d/_w_d/.done"
+test "$(find "$rootmnt/writable/system-data/" | wc -l)" = 3
+set +x
 # cleanup
 rm -f "$rootmnt/writable/system-data/_writable_defaults/.done"
 
-# test: file/dir in _writable_defaults
+# test: file/dir/symlinks in _writable_defaults
 mkdir -p "$rootmnt/writable/system-data/_writable_defaults/some-dir"
 touch "$rootmnt/writable/system-data/_writable_defaults/some-dir/some-file"
 touch "$rootmnt/writable/system-data/_writable_defaults/other-file"
+ln -s "other-file" "$rootmnt/writable/system-data/_writable_defaults/some-link"
+ln -s "no-file" "$rootmnt/writable/system-data/_writable_defaults/broken-link"
 
 handle_writable_defaults
 # ensure we have the .done file
+echo "Testing files/dirs/symlinks in _writable_defaults work"
+set -x
 test -e "$rootmnt/writable/system-data/_writable_defaults/.done"
 test -d "$rootmnt/writable/system-data/some-dir"
 test -e "$rootmnt/writable/system-data/some-dir/some-file"
 test -e "$rootmnt/writable/system-data/other-file"
+test -L "$rootmnt/writable/system-data/some-link"
+test -L "$rootmnt/writable/system-data/broken-link"
+set +x
 # cleanup
 rm -f "$rootmnt/writable/system-data/_writable_defaults/.done"


### PR DESCRIPTION
The new handle_writable_defaults() helper will take the defaults
from $writable/system-data/_writable_defaults/ and apply them on top of
the populated $writable/system-data.

This will allow providing image defaults in a clean way.

This will also get ported to UC20.